### PR TITLE
Remove Google Analytics

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,14 +35,3 @@ var _hmt = _hmt || [];
 </script>
 {% endif %}
 <!-- 谷歌分析 -->
-{% if site.google %}
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google-ID }}"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', '{{ site.google-ID }}');
-</script>
-{% endif %}


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/